### PR TITLE
fix: solve invisible text on safari browser for the typewriter component

### DIFF
--- a/src/components/React/Typewriter.jsx
+++ b/src/components/React/Typewriter.jsx
@@ -49,7 +49,9 @@ const Typewriter = ({ words, speed = 150, pause = 2000 }) => {
   return (
     <span className="inline-flex items-center">
       {/* The Text */}
-      <span>{words[index] ? words[index].substring(0, subIndex) : ''}</span>
+      <span className="text-transparent bg-clip-text bg-gradient-to-r from-unam-blue to-cyan-400">
+        {words[index] ? words[index].substring(0, subIndex) : ''}
+      </span>
 
       {/* The Cursor */}
       <span

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,9 +52,7 @@ const wikiEntries = await getLatestWikiEntries(3);
 
           <h1 class="text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6 leading-tight">
             Domina <br />
-            <span class="text-transparent bg-clip-text bg-gradient-to-r from-unam-blue to-cyan-400">
-              <Typewriter client:visible words={TYPEWRITER_WORDS} />
-            </span>
+            <Typewriter client:visible words={TYPEWRITER_WORDS} />
           </h1>
 
           <p


### PR DESCRIPTION
Fixes #9 
Problem: The typewriter text in the Hero section was invisible in Safari. This occurred due to a known rendering bug in WebKit where the background-clip: text utility fails when the element or its immediate children use display: flex or inline-flex.

Solution:
I decoupled the gradient styling from the flexbox layout. Specifically:

Removed the text-transparent, bg-clip-text, and gradient classes from the parent wrapper in src/pages/index.astro.

Applied those same gradient classes directly to the inner span that handles the text rendering inside src/components/React/Typewriter.jsx.